### PR TITLE
Add C bindings for RaptorQ FEC

### DIFF
--- a/c-bindings/.gitignore
+++ b/c-bindings/.gitignore
@@ -1,0 +1,6 @@
+/target/
+Cargo.lock
+*.so
+*.a
+*.dylib
+test_raptorq

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "raptorq-c"
+version = "0.1.0"
+edition = "2021"
+description = "C bindings for RaptorQ FEC encoding/decoding"
+
+[lib]
+name = "raptorq_c"
+crate-type = ["staticlib", "cdylib"]
+
+[dependencies]
+raptorq = { path = "../internal/raptorq", default-features = false }
+
+[profile.release]
+opt-level = 3
+lto = true

--- a/c-bindings/Makefile
+++ b/c-bindings/Makefile
@@ -1,0 +1,51 @@
+# RaptorQ C Bindings Makefile
+
+RUST_TARGET_DIR = target/release
+LIB_NAME = raptorq_c
+
+# Library outputs
+STATIC_LIB = $(RUST_TARGET_DIR)/lib$(LIB_NAME).a
+SHARED_LIB = $(RUST_TARGET_DIR)/lib$(LIB_NAME).so
+
+# Installation paths (customizable)
+PREFIX ?= /usr/local
+LIBDIR ?= $(PREFIX)/lib
+INCLUDEDIR ?= $(PREFIX)/include
+
+.PHONY: all clean test install debug release
+
+all: release
+
+release:
+	cargo build --release
+
+debug:
+	cargo build
+
+test: release
+	cargo test
+	$(CC) -o test_raptorq test/test_raptorq.c -I include -L $(RUST_TARGET_DIR) -l$(LIB_NAME) -lpthread -ldl -lm
+	LD_LIBRARY_PATH=$(RUST_TARGET_DIR) ./test_raptorq
+
+clean:
+	cargo clean
+	rm -f test_raptorq
+
+install: release
+	mkdir -p $(LIBDIR) $(INCLUDEDIR)
+	cp $(STATIC_LIB) $(LIBDIR)/
+	cp $(SHARED_LIB) $(LIBDIR)/
+	cp include/raptorq.h $(INCLUDEDIR)/
+	ldconfig || true
+
+# Print library info
+info:
+	@echo "RaptorQ C Bindings"
+	@echo "=================="
+	@echo "Static library: $(STATIC_LIB)"
+	@echo "Shared library: $(SHARED_LIB)"
+	@echo "Header:         include/raptorq.h"
+	@echo ""
+	@echo "Link flags:"
+	@echo "  CFLAGS:  -I$(CURDIR)/include"
+	@echo "  LDFLAGS: -L$(CURDIR)/$(RUST_TARGET_DIR) -lraptorq_c -lpthread -ldl -lm"

--- a/c-bindings/include/raptorq.h
+++ b/c-bindings/include/raptorq.h
@@ -1,0 +1,260 @@
+/**
+ * RaptorQ FEC C Bindings
+ *
+ * RFC 6330 Forward Error Correction implementation.
+ *
+ * Usage:
+ *   1. Create encoder with raptorq_encoder_new()
+ *   2. Get OTI with raptorq_encoder_get_oti() - must be sent to decoder
+ *   3. Get source packets with raptorq_encoder_get_source_packets()
+ *   4. Get repair packets with raptorq_encoder_get_repair_packets()
+ *   5. Create decoder with raptorq_decoder_new()
+ *   6. Add packets with raptorq_decoder_add_packet()
+ *   7. Check completion with raptorq_decoder_is_complete()
+ */
+
+#ifndef RAPTORQ_H
+#define RAPTORQ_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handles */
+typedef struct RaptorQEncoderC RaptorQEncoder;
+typedef struct RaptorQDecoderC RaptorQDecoder;
+
+/**
+ * OTI (Object Transmission Information) - 12 bytes per RFC 6330
+ * Must be transmitted from encoder to decoder.
+ */
+typedef struct {
+    uint8_t bytes[12];
+} RaptorQOTI;
+
+/* ============================================================================
+ * Encoder API
+ * ============================================================================ */
+
+/**
+ * Create a new RaptorQ encoder
+ *
+ * @param data         Pointer to data to encode
+ * @param data_len     Length of data in bytes
+ * @param symbol_size  Size of each symbol (typically 1024-1280 for network MTU)
+ * @param repair_symbols Number of repair symbols to generate per block
+ *
+ * @return Encoder handle or NULL on error
+ */
+RaptorQEncoder* raptorq_encoder_new(
+    const uint8_t* data,
+    size_t data_len,
+    uint16_t symbol_size,
+    uint32_t repair_symbols
+);
+
+/**
+ * Free encoder resources
+ */
+void raptorq_encoder_free(RaptorQEncoder* encoder);
+
+/**
+ * Get OTI (Object Transmission Information)
+ * Must be transmitted to decoder for proper decoding.
+ *
+ * @param encoder  Encoder handle
+ * @param oti      Output OTI structure
+ *
+ * @return 0 on success, -1 on error
+ */
+int raptorq_encoder_get_oti(
+    const RaptorQEncoder* encoder,
+    RaptorQOTI* oti
+);
+
+/**
+ * Get transfer length (original data size)
+ */
+uint64_t raptorq_encoder_transfer_length(const RaptorQEncoder* encoder);
+
+/**
+ * Get symbol size
+ */
+uint16_t raptorq_encoder_symbol_size(const RaptorQEncoder* encoder);
+
+/**
+ * Get packet size (4-byte PayloadId + symbol)
+ */
+size_t raptorq_encoder_packet_size(const RaptorQEncoder* encoder);
+
+/**
+ * Get number of source symbols for block 0
+ */
+uint32_t raptorq_encoder_source_symbol_count(const RaptorQEncoder* encoder);
+
+/**
+ * Get all source packets for block 0
+ * Returns concatenated serialized packets (each is 4-byte PayloadId + symbol)
+ *
+ * @param encoder   Encoder handle
+ * @param out_data  Output buffer (must be large enough)
+ * @param out_len   On input: buffer size. On output: bytes written
+ *
+ * @return 0 on success, -1 on error (buffer too small)
+ */
+int raptorq_encoder_get_source_packets(
+    const RaptorQEncoder* encoder,
+    uint8_t* out_data,
+    size_t* out_len
+);
+
+/**
+ * Get repair packets for block 0
+ *
+ * @param encoder     Encoder handle
+ * @param start_index Starting repair symbol index
+ * @param count       Number of repair symbols to generate
+ * @param out_data    Output buffer
+ * @param out_len     On input: buffer size. On output: bytes written
+ *
+ * @return 0 on success, -1 on error
+ */
+int raptorq_encoder_get_repair_packets(
+    const RaptorQEncoder* encoder,
+    uint32_t start_index,
+    uint32_t count,
+    uint8_t* out_data,
+    size_t* out_len
+);
+
+/* ============================================================================
+ * Decoder API
+ * ============================================================================ */
+
+/**
+ * Create a new RaptorQ decoder from OTI
+ *
+ * @param oti  OTI from encoder
+ *
+ * @return Decoder handle or NULL on error
+ */
+RaptorQDecoder* raptorq_decoder_new(const RaptorQOTI* oti);
+
+/**
+ * Create decoder with explicit parameters (no OTI needed)
+ */
+RaptorQDecoder* raptorq_decoder_new_with_params(
+    uint64_t transfer_length,
+    uint16_t symbol_size,
+    uint8_t source_blocks,
+    uint16_t sub_blocks,
+    uint8_t symbol_alignment
+);
+
+/**
+ * Free decoder resources
+ */
+void raptorq_decoder_free(RaptorQDecoder* decoder);
+
+/**
+ * Add a packet to the decoder
+ *
+ * @param decoder    Decoder handle
+ * @param packet     Serialized packet (4-byte PayloadId + symbol)
+ * @param packet_len Packet length
+ *
+ * @return 1 if decoding complete, 0 if more packets needed, -1 on error
+ */
+int raptorq_decoder_add_packet(
+    RaptorQDecoder* decoder,
+    const uint8_t* packet,
+    size_t packet_len
+);
+
+/**
+ * Check if decoding is complete
+ *
+ * @return 1 if complete, 0 otherwise
+ */
+int raptorq_decoder_is_complete(const RaptorQDecoder* decoder);
+
+/**
+ * Get transfer length
+ */
+uint64_t raptorq_decoder_transfer_length(const RaptorQDecoder* decoder);
+
+/**
+ * Get symbol size
+ */
+uint16_t raptorq_decoder_symbol_size(const RaptorQDecoder* decoder);
+
+/**
+ * Get expected packet size
+ */
+size_t raptorq_decoder_packet_size(const RaptorQDecoder* decoder);
+
+/**
+ * Get decoded data after decoding is complete
+ *
+ * @param decoder  Decoder handle
+ * @param out_data Output buffer (must be large enough for transfer_length bytes)
+ * @param max_len  Maximum bytes to write (buffer size)
+ * @param out_len  On output: actual bytes written
+ *
+ * @return 0 on success, -1 if decoding not complete or error
+ */
+int raptorq_decoder_get_data(
+    const RaptorQDecoder* decoder,
+    uint8_t* out_data,
+    size_t max_len,
+    size_t* out_len
+);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================ */
+
+/**
+ * Create OTI from parameters
+ *
+ * @param transfer_length  Total data length
+ * @param symbol_size      Symbol size in bytes
+ * @param source_blocks    Number of source blocks (usually 1)
+ * @param sub_blocks       Number of sub-blocks (usually 1)
+ * @param symbol_alignment Alignment in bytes (usually 8)
+ * @param oti              Output OTI structure
+ *
+ * @return 0 on success, -1 on error
+ */
+int raptorq_create_oti(
+    uint64_t transfer_length,
+    uint16_t symbol_size,
+    uint8_t source_blocks,
+    uint16_t sub_blocks,
+    uint8_t symbol_alignment,
+    RaptorQOTI* oti
+);
+
+/**
+ * Parse OTI and extract transfer length
+ */
+uint64_t raptorq_oti_transfer_length(const RaptorQOTI* oti);
+
+/**
+ * Parse OTI and extract symbol size
+ */
+uint16_t raptorq_oti_symbol_size(const RaptorQOTI* oti);
+
+/**
+ * Free memory allocated by this library
+ */
+void raptorq_free(uint8_t* ptr, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RAPTORQ_H */

--- a/c-bindings/src/lib.rs
+++ b/c-bindings/src/lib.rs
@@ -1,0 +1,524 @@
+//! C bindings for RaptorQ FEC encoding/decoding
+//!
+//! Provides FFI-safe interface for RFC 6330 RaptorQ.
+
+use std::ptr;
+use std::slice;
+use raptorq::{Encoder, Decoder, ObjectTransmissionInformation, EncodingPacket};
+
+/// Opaque encoder handle
+pub struct RaptorQEncoderC {
+    encoder: Encoder,
+    config: ObjectTransmissionInformation,
+}
+
+/// Opaque decoder handle
+pub struct RaptorQDecoderC {
+    decoder: Decoder,
+    config: ObjectTransmissionInformation,
+    is_complete: bool,
+    decoded_data: Option<Vec<u8>>,
+}
+
+/// Result structure for encoding operations
+#[repr(C)]
+pub struct RaptorQResult {
+    pub data: *mut u8,
+    pub len: usize,
+    pub success: i32,
+}
+
+/// OTI (Object Transmission Information) structure - 12 bytes per RFC 6330
+#[repr(C)]
+pub struct RaptorQOTI {
+    pub bytes: [u8; 12],
+}
+
+// ============================================================================
+// Encoder API
+// ============================================================================
+
+/// Create a new RaptorQ encoder
+///
+/// # Arguments
+/// * `data` - Pointer to data to encode
+/// * `data_len` - Length of data
+/// * `symbol_size` - Size of each symbol (typically 1024-1280 for network MTU)
+/// * `repair_symbols` - Number of repair symbols to generate per block
+///
+/// # Returns
+/// Encoder handle or NULL on error
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_new(
+    data: *const u8,
+    data_len: usize,
+    symbol_size: u16,
+    _repair_symbols: u32,
+) -> *mut RaptorQEncoderC {
+    if data.is_null() || data_len == 0 {
+        return ptr::null_mut();
+    }
+
+    let data_slice = unsafe { slice::from_raw_parts(data, data_len) };
+
+    // Use standard parameters: 1 source block, 1 sub-block, 8-byte alignment
+    let config = ObjectTransmissionInformation::new(
+        data_len as u64,
+        symbol_size,
+        1,  // source_blocks
+        1,  // sub_blocks
+        8,  // symbol_alignment
+    );
+
+    let encoder = Encoder::new(data_slice, config);
+
+    let enc = Box::new(RaptorQEncoderC {
+        encoder,
+        config,
+    });
+
+    Box::into_raw(enc)
+}
+
+/// Free encoder resources
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_free(encoder: *mut RaptorQEncoderC) {
+    if !encoder.is_null() {
+        unsafe { drop(Box::from_raw(encoder)); }
+    }
+}
+
+/// Get OTI (Object Transmission Information) for this encoder
+/// Must be transmitted to decoder for proper decoding
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_get_oti(
+    encoder: *const RaptorQEncoderC,
+    oti: *mut RaptorQOTI,
+) -> i32 {
+    if encoder.is_null() || oti.is_null() {
+        return -1;
+    }
+
+    let enc = unsafe { &*encoder };
+    let serialized = enc.config.serialize();
+
+    unsafe {
+        (*oti).bytes.copy_from_slice(&serialized);
+    }
+
+    0
+}
+
+/// Get transfer length (original data size)
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_transfer_length(encoder: *const RaptorQEncoderC) -> u64 {
+    if encoder.is_null() {
+        return 0;
+    }
+    let enc = unsafe { &*encoder };
+    enc.config.transfer_length()
+}
+
+/// Get symbol size
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_symbol_size(encoder: *const RaptorQEncoderC) -> u16 {
+    if encoder.is_null() {
+        return 0;
+    }
+    let enc = unsafe { &*encoder };
+    enc.config.symbol_size()
+}
+
+/// Get packet size (4-byte PayloadId + symbol)
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_packet_size(encoder: *const RaptorQEncoderC) -> usize {
+    if encoder.is_null() {
+        return 0;
+    }
+    let enc = unsafe { &*encoder };
+    4 + enc.config.symbol_size() as usize
+}
+
+/// Get number of source symbols for block 0
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_source_symbol_count(encoder: *const RaptorQEncoderC) -> u32 {
+    if encoder.is_null() {
+        return 0;
+    }
+    let enc = unsafe { &*encoder };
+    let block_encoders = enc.encoder.get_block_encoders();
+    if block_encoders.is_empty() {
+        return 0;
+    }
+    block_encoders[0].source_packets().len() as u32
+}
+
+/// Get all source packets for block 0
+/// Returns concatenated serialized packets (each is 4-byte PayloadId + symbol)
+///
+/// # Arguments
+/// * `encoder` - Encoder handle
+/// * `out_data` - Output buffer (must be large enough)
+/// * `out_len` - On input: buffer size. On output: bytes written
+///
+/// # Returns
+/// 0 on success, -1 on error
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_get_source_packets(
+    encoder: *const RaptorQEncoderC,
+    out_data: *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if encoder.is_null() || out_data.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let enc = unsafe { &*encoder };
+    let block_encoders = enc.encoder.get_block_encoders();
+
+    if block_encoders.is_empty() {
+        unsafe { *out_len = 0; }
+        return 0;
+    }
+
+    let packets = block_encoders[0].source_packets();
+    let mut result = Vec::new();
+
+    for packet in packets {
+        result.extend_from_slice(&packet.serialize());
+    }
+
+    let max_len = unsafe { *out_len };
+    if result.len() > max_len {
+        return -1;  // Buffer too small
+    }
+
+    unsafe {
+        ptr::copy_nonoverlapping(result.as_ptr(), out_data, result.len());
+        *out_len = result.len();
+    }
+
+    0
+}
+
+/// Get repair packets for block 0
+///
+/// # Arguments
+/// * `encoder` - Encoder handle
+/// * `start_index` - Starting repair symbol index
+/// * `count` - Number of repair symbols to generate
+/// * `out_data` - Output buffer
+/// * `out_len` - On input: buffer size. On output: bytes written
+///
+/// # Returns
+/// 0 on success, -1 on error
+#[no_mangle]
+pub extern "C" fn raptorq_encoder_get_repair_packets(
+    encoder: *const RaptorQEncoderC,
+    start_index: u32,
+    count: u32,
+    out_data: *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if encoder.is_null() || out_data.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let enc = unsafe { &*encoder };
+    let block_encoders = enc.encoder.get_block_encoders();
+
+    if block_encoders.is_empty() {
+        unsafe { *out_len = 0; }
+        return 0;
+    }
+
+    let packets = block_encoders[0].repair_packets(start_index, count);
+    let mut result = Vec::new();
+
+    for packet in packets {
+        result.extend_from_slice(&packet.serialize());
+    }
+
+    let max_len = unsafe { *out_len };
+    if result.len() > max_len {
+        return -1;  // Buffer too small
+    }
+
+    unsafe {
+        ptr::copy_nonoverlapping(result.as_ptr(), out_data, result.len());
+        *out_len = result.len();
+    }
+
+    0
+}
+
+// ============================================================================
+// Decoder API
+// ============================================================================
+
+/// Create a new RaptorQ decoder from OTI
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_new(oti: *const RaptorQOTI) -> *mut RaptorQDecoderC {
+    if oti.is_null() {
+        return ptr::null_mut();
+    }
+
+    let oti_bytes = unsafe { &(*oti).bytes };
+    let config = ObjectTransmissionInformation::deserialize(oti_bytes);
+    let decoder = Decoder::new(config);
+
+    let dec = Box::new(RaptorQDecoderC {
+        decoder,
+        config,
+        is_complete: false,
+        decoded_data: None,
+    });
+
+    Box::into_raw(dec)
+}
+
+/// Create decoder with explicit parameters (no OTI needed)
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_new_with_params(
+    transfer_length: u64,
+    symbol_size: u16,
+    source_blocks: u8,
+    sub_blocks: u16,
+    symbol_alignment: u8,
+) -> *mut RaptorQDecoderC {
+    let config = ObjectTransmissionInformation::new(
+        transfer_length,
+        symbol_size,
+        source_blocks,
+        sub_blocks,
+        symbol_alignment,
+    );
+    let decoder = Decoder::new(config);
+
+    let dec = Box::new(RaptorQDecoderC {
+        decoder,
+        config,
+        is_complete: false,
+        decoded_data: None,
+    });
+
+    Box::into_raw(dec)
+}
+
+/// Free decoder resources
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_free(decoder: *mut RaptorQDecoderC) {
+    if !decoder.is_null() {
+        unsafe { drop(Box::from_raw(decoder)); }
+    }
+}
+
+/// Add a packet to the decoder
+///
+/// # Arguments
+/// * `decoder` - Decoder handle
+/// * `packet` - Serialized packet (4-byte PayloadId + symbol)
+/// * `packet_len` - Packet length
+///
+/// # Returns
+/// 1 if decoding is now complete, 0 if more packets needed, -1 on error
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_add_packet(
+    decoder: *mut RaptorQDecoderC,
+    packet: *const u8,
+    packet_len: usize,
+) -> i32 {
+    if decoder.is_null() || packet.is_null() {
+        return -1;
+    }
+
+    let dec = unsafe { &mut *decoder };
+
+    if dec.is_complete {
+        return 1;
+    }
+
+    let expected_size = 4 + dec.config.symbol_size() as usize;
+    if packet_len != expected_size {
+        return -1;
+    }
+
+    let packet_slice = unsafe { slice::from_raw_parts(packet, packet_len) };
+    let encoding_packet = EncodingPacket::deserialize(packet_slice);
+
+    if let Some(data) = dec.decoder.decode(encoding_packet) {
+        dec.is_complete = true;
+        dec.decoded_data = Some(data);
+        return 1;
+    }
+
+    0
+}
+
+/// Check if decoding is complete
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_is_complete(decoder: *const RaptorQDecoderC) -> i32 {
+    if decoder.is_null() {
+        return 0;
+    }
+    let dec = unsafe { &*decoder };
+    if dec.is_complete { 1 } else { 0 }
+}
+
+/// Get transfer length
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_transfer_length(decoder: *const RaptorQDecoderC) -> u64 {
+    if decoder.is_null() {
+        return 0;
+    }
+    let dec = unsafe { &*decoder };
+    dec.config.transfer_length()
+}
+
+/// Get symbol size
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_symbol_size(decoder: *const RaptorQDecoderC) -> u16 {
+    if decoder.is_null() {
+        return 0;
+    }
+    let dec = unsafe { &*decoder };
+    dec.config.symbol_size()
+}
+
+/// Get expected packet size
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_packet_size(decoder: *const RaptorQDecoderC) -> usize {
+    if decoder.is_null() {
+        return 0;
+    }
+    let dec = unsafe { &*decoder };
+    4 + dec.config.symbol_size() as usize
+}
+
+/// Get decoded data after decoding is complete
+///
+/// # Arguments
+/// * `decoder` - Decoder handle
+/// * `out_data` - Output buffer (must be large enough for transfer_length bytes)
+/// * `out_len` - On input: buffer size. On output: bytes written
+///
+/// # Returns
+/// 0 on success, -1 if decoding not complete or error
+#[no_mangle]
+pub extern "C" fn raptorq_decoder_get_data(
+    decoder: *const RaptorQDecoderC,
+    out_data: *mut u8,
+    max_len: usize,
+    out_len: *mut usize,
+) -> i32 {
+    if decoder.is_null() || out_data.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let dec = unsafe { &*decoder };
+
+    if !dec.is_complete {
+        return -1;  // Decoding not complete
+    }
+
+    match &dec.decoded_data {
+        Some(data) => {
+            if data.len() > max_len {
+                return -1;  // Buffer too small
+            }
+            unsafe {
+                ptr::copy_nonoverlapping(data.as_ptr(), out_data, data.len());
+                *out_len = data.len();
+            }
+            0
+        }
+        None => -1,  // No data available
+    }
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/// Create OTI from parameters
+#[no_mangle]
+pub extern "C" fn raptorq_create_oti(
+    transfer_length: u64,
+    symbol_size: u16,
+    source_blocks: u8,
+    sub_blocks: u16,
+    symbol_alignment: u8,
+    oti: *mut RaptorQOTI,
+) -> i32 {
+    if oti.is_null() {
+        return -1;
+    }
+
+    let config = ObjectTransmissionInformation::new(
+        transfer_length,
+        symbol_size,
+        source_blocks,
+        sub_blocks,
+        symbol_alignment,
+    );
+
+    unsafe {
+        (*oti).bytes.copy_from_slice(&config.serialize());
+    }
+
+    0
+}
+
+/// Parse OTI bytes and extract transfer length
+#[no_mangle]
+pub extern "C" fn raptorq_oti_transfer_length(oti: *const RaptorQOTI) -> u64 {
+    if oti.is_null() {
+        return 0;
+    }
+    let oti_bytes = unsafe { &(*oti).bytes };
+    let config = ObjectTransmissionInformation::deserialize(oti_bytes);
+    config.transfer_length()
+}
+
+/// Parse OTI bytes and extract symbol size
+#[no_mangle]
+pub extern "C" fn raptorq_oti_symbol_size(oti: *const RaptorQOTI) -> u16 {
+    if oti.is_null() {
+        return 0;
+    }
+    let oti_bytes = unsafe { &(*oti).bytes };
+    let config = ObjectTransmissionInformation::deserialize(oti_bytes);
+    config.symbol_size()
+}
+
+/// Free memory allocated by this library
+#[no_mangle]
+pub extern "C" fn raptorq_free(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        unsafe {
+            let _ = Vec::from_raw_parts(ptr, len, len);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        let data = vec![0u8; 1000];
+
+        let encoder = raptorq_encoder_new(data.as_ptr(), data.len(), 128, 5);
+        assert!(!encoder.is_null());
+
+        let mut oti = RaptorQOTI { bytes: [0; 12] };
+        assert_eq!(raptorq_encoder_get_oti(encoder, &mut oti), 0);
+
+        let decoder = raptorq_decoder_new(&oti);
+        assert!(!decoder.is_null());
+
+        raptorq_encoder_free(encoder);
+        raptorq_decoder_free(decoder);
+    }
+}

--- a/c-bindings/test/test_raptorq.c
+++ b/c-bindings/test/test_raptorq.c
@@ -1,0 +1,266 @@
+/**
+ * RaptorQ C Bindings Test
+ *
+ * Tests the RaptorQ encoder/decoder C API.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "raptorq.h"
+
+#define TEST_DATA_SIZE 1000
+#define SYMBOL_SIZE 128
+#define REPAIR_SYMBOLS 5
+
+int test_encode_decode(void) {
+    printf("Test: Basic encode/decode\n");
+
+    /* Create test data */
+    uint8_t* data = malloc(TEST_DATA_SIZE);
+    if (!data) {
+        printf("  FAIL: malloc failed\n");
+        return -1;
+    }
+
+    for (int i = 0; i < TEST_DATA_SIZE; i++) {
+        data[i] = i & 0xFF;
+    }
+
+    /* Create encoder */
+    RaptorQEncoder* encoder = raptorq_encoder_new(data, TEST_DATA_SIZE, SYMBOL_SIZE, REPAIR_SYMBOLS);
+    if (!encoder) {
+        printf("  FAIL: encoder creation failed\n");
+        free(data);
+        return -1;
+    }
+
+    printf("  Encoder created successfully\n");
+    printf("  Transfer length: %lu\n", (unsigned long)raptorq_encoder_transfer_length(encoder));
+    printf("  Symbol size: %u\n", raptorq_encoder_symbol_size(encoder));
+    printf("  Packet size: %zu\n", raptorq_encoder_packet_size(encoder));
+    printf("  Source symbols: %u\n", raptorq_encoder_source_symbol_count(encoder));
+
+    /* Get OTI */
+    RaptorQOTI oti;
+    if (raptorq_encoder_get_oti(encoder, &oti) != 0) {
+        printf("  FAIL: get_oti failed\n");
+        raptorq_encoder_free(encoder);
+        free(data);
+        return -1;
+    }
+
+    printf("  OTI: ");
+    for (int i = 0; i < 12; i++) {
+        printf("%02x ", oti.bytes[i]);
+    }
+    printf("\n");
+
+    /* Get source packets */
+    size_t packet_size = raptorq_encoder_packet_size(encoder);
+    uint32_t source_count = raptorq_encoder_source_symbol_count(encoder);
+    size_t source_buf_size = source_count * packet_size;
+    uint8_t* source_packets = malloc(source_buf_size);
+
+    if (raptorq_encoder_get_source_packets(encoder, source_packets, &source_buf_size) != 0) {
+        printf("  FAIL: get_source_packets failed\n");
+        free(source_packets);
+        raptorq_encoder_free(encoder);
+        free(data);
+        return -1;
+    }
+
+    printf("  Got %zu bytes of source packets\n", source_buf_size);
+
+    /* Get repair packets */
+    size_t repair_buf_size = REPAIR_SYMBOLS * packet_size;
+    uint8_t* repair_packets = malloc(repair_buf_size);
+
+    if (raptorq_encoder_get_repair_packets(encoder, 0, REPAIR_SYMBOLS, repair_packets, &repair_buf_size) != 0) {
+        printf("  FAIL: get_repair_packets failed\n");
+        free(repair_packets);
+        free(source_packets);
+        raptorq_encoder_free(encoder);
+        free(data);
+        return -1;
+    }
+
+    printf("  Got %zu bytes of repair packets\n", repair_buf_size);
+
+    raptorq_encoder_free(encoder);
+
+    /* Create decoder */
+    RaptorQDecoder* decoder = raptorq_decoder_new(&oti);
+    if (!decoder) {
+        printf("  FAIL: decoder creation failed\n");
+        free(repair_packets);
+        free(source_packets);
+        free(data);
+        return -1;
+    }
+
+    printf("  Decoder created successfully\n");
+    printf("  Expected transfer length: %lu\n", (unsigned long)raptorq_decoder_transfer_length(decoder));
+
+    /* Feed packets to decoder */
+    int packets_added = 0;
+    for (size_t i = 0; i < source_buf_size; i += packet_size) {
+        int result = raptorq_decoder_add_packet(decoder, source_packets + i, packet_size);
+        packets_added++;
+
+        if (result == 1) {
+            printf("  Decoding complete after %d source packets!\n", packets_added);
+            break;
+        } else if (result == -1) {
+            printf("  FAIL: add_packet returned error\n");
+            break;
+        }
+    }
+
+    if (!raptorq_decoder_is_complete(decoder)) {
+        printf("  FAIL: decoding not complete after all source packets\n");
+        raptorq_decoder_free(decoder);
+        free(repair_packets);
+        free(source_packets);
+        free(data);
+        return -1;
+    }
+
+    raptorq_decoder_free(decoder);
+    free(repair_packets);
+    free(source_packets);
+    free(data);
+
+    printf("  PASS\n\n");
+    return 0;
+}
+
+int test_loss_recovery(void) {
+    printf("Test: Packet loss recovery\n");
+
+    /* Create test data */
+    uint8_t* data = malloc(TEST_DATA_SIZE);
+    for (int i = 0; i < TEST_DATA_SIZE; i++) {
+        data[i] = i & 0xFF;
+    }
+
+    /* Create encoder with more repair symbols */
+    RaptorQEncoder* encoder = raptorq_encoder_new(data, TEST_DATA_SIZE, SYMBOL_SIZE, 10);
+    if (!encoder) {
+        printf("  FAIL: encoder creation failed\n");
+        free(data);
+        return -1;
+    }
+
+    RaptorQOTI oti;
+    raptorq_encoder_get_oti(encoder, &oti);
+
+    size_t packet_size = raptorq_encoder_packet_size(encoder);
+    uint32_t source_count = raptorq_encoder_source_symbol_count(encoder);
+
+    /* Get source packets */
+    size_t source_buf_size = source_count * packet_size;
+    uint8_t* source_packets = malloc(source_buf_size);
+    raptorq_encoder_get_source_packets(encoder, source_packets, &source_buf_size);
+
+    /* Get repair packets */
+    size_t repair_buf_size = 10 * packet_size;
+    uint8_t* repair_packets = malloc(repair_buf_size);
+    raptorq_encoder_get_repair_packets(encoder, 0, 10, repair_packets, &repair_buf_size);
+
+    raptorq_encoder_free(encoder);
+
+    /* Create decoder and simulate loss */
+    RaptorQDecoder* decoder = raptorq_decoder_new(&oti);
+
+    printf("  Skipping first 3 source packets (simulating loss)\n");
+
+    /* Skip first 3 source packets, feed the rest */
+    int packets_added = 0;
+    for (size_t i = 3 * packet_size; i < source_buf_size; i += packet_size) {
+        int result = raptorq_decoder_add_packet(decoder, source_packets + i, packet_size);
+        packets_added++;
+        if (result == 1) {
+            printf("  Decoding complete after %d source packets (no repair needed)!\n", packets_added);
+            goto done;
+        }
+    }
+
+    /* Add repair packets */
+    printf("  Adding repair packets...\n");
+    for (size_t i = 0; i < repair_buf_size; i += packet_size) {
+        int result = raptorq_decoder_add_packet(decoder, repair_packets + i, packet_size);
+        packets_added++;
+        if (result == 1) {
+            printf("  Decoding complete after adding %zu repair packets!\n", (i / packet_size) + 1);
+            goto done;
+        }
+    }
+
+    if (!raptorq_decoder_is_complete(decoder)) {
+        printf("  FAIL: decoding not complete\n");
+        raptorq_decoder_free(decoder);
+        free(repair_packets);
+        free(source_packets);
+        free(data);
+        return -1;
+    }
+
+done:
+    raptorq_decoder_free(decoder);
+    free(repair_packets);
+    free(source_packets);
+    free(data);
+
+    printf("  PASS\n\n");
+    return 0;
+}
+
+int test_oti_functions(void) {
+    printf("Test: OTI utility functions\n");
+
+    RaptorQOTI oti;
+    if (raptorq_create_oti(TEST_DATA_SIZE, SYMBOL_SIZE, 1, 1, 8, &oti) != 0) {
+        printf("  FAIL: create_oti failed\n");
+        return -1;
+    }
+
+    uint64_t transfer_len = raptorq_oti_transfer_length(&oti);
+    uint16_t symbol_size = raptorq_oti_symbol_size(&oti);
+
+    printf("  Created OTI for %lu bytes, symbol size %u\n",
+           (unsigned long)transfer_len, symbol_size);
+
+    if (transfer_len != TEST_DATA_SIZE) {
+        printf("  FAIL: transfer length mismatch\n");
+        return -1;
+    }
+
+    if (symbol_size != SYMBOL_SIZE) {
+        printf("  FAIL: symbol size mismatch\n");
+        return -1;
+    }
+
+    printf("  PASS\n\n");
+    return 0;
+}
+
+int main(void) {
+    printf("RaptorQ C Bindings Test Suite\n");
+    printf("=============================\n\n");
+
+    int failures = 0;
+
+    if (test_oti_functions() != 0) failures++;
+    if (test_encode_decode() != 0) failures++;
+    if (test_loss_recovery() != 0) failures++;
+
+    printf("=============================\n");
+    if (failures == 0) {
+        printf("All tests passed!\n");
+        return 0;
+    } else {
+        printf("%d test(s) failed\n", failures);
+        return 1;
+    }
+}


### PR DESCRIPTION
- Add C API for RaptorQ encoder/decoder
- Implement raptorq_encoder_* and raptorq_decoder_* functions
- Add raptorq_decoder_get_result() to retrieve decoded data
- Include header file and Makefile for integration
- Add C test suite with packet loss recovery test